### PR TITLE
Check if Ingest input contain http://

### DIFF
--- a/src/services/connectorService.ts
+++ b/src/services/connectorService.ts
@@ -43,7 +43,8 @@ export class ConnectorService {
     }
 
     handleAuthProcess(ingestIp: string, obsName: string, groupCode: string, leftTeam: AuthTeam, rightTeam: AuthTeam, key: string, win: Electron.Main.BrowserWindow) {
-        this.INGEST_SERVER_URL = `https://${ingestIp}:5100`;
+        if (ingestIp.startsWith("http://")) {this.INGEST_SERVER_URL = `${ingestIp}:5100`;}
+        else {this.INGEST_SERVER_URL = `https://${ingestIp}:5100`;}
         this.OBS_NAME = obsName;
         this.GROUP_CODE = groupCode.toUpperCase();
         this.LEFT_TEAM = leftTeam;


### PR DESCRIPTION
Same as #3 , but instead of adding a checkbox to the GUI, it checks if ```Enter the ingest server IP``` input contain ```http://[*]```, if ```true``` then the client will connect to server using http instead of https by default. 

Not recommended in production but rather should be a way to test the system out (eg: running on localhost or mesh-network) before making it ready for production.