### PR TITLE
add regex for url input validation.

### DIFF
--- a/src/services/connectorService.ts
+++ b/src/services/connectorService.ts
@@ -50,7 +50,6 @@ export class ConnectorService {
         } else {
             this.INGEST_SERVER_URL = ingestIp.startsWith('http') ? `${ingestIp}:5100` : `https://${ingestIp}:5100`
         }
-        log.info(this.INGEST_SERVER_URL)
         this.OBS_NAME = obsName;
         this.GROUP_CODE = groupCode.toUpperCase();
         this.LEFT_TEAM = leftTeam;

--- a/src/services/connectorService.ts
+++ b/src/services/connectorService.ts
@@ -43,7 +43,7 @@ export class ConnectorService {
     }
 
     handleAuthProcess(ingestIp: string, obsName: string, groupCode: string, leftTeam: AuthTeam, rightTeam: AuthTeam, key: string, win: Electron.Main.BrowserWindow) {
-        if (RegExp('(http|https)://[^/]+:[0-9]+').test(ingestIp)) {
+        if (RegExp('(http|https):\/\/[^\/]+:[0-9]+').test(ingestIp)) {
             this.INGEST_SERVER_URL = `${ingestIp}`
         } else if (ingestIp.includes(':') && !(ingestIp.startsWith('http'))) {
             this.INGEST_SERVER_URL = `https://${ingestIp}`

--- a/src/services/connectorService.ts
+++ b/src/services/connectorService.ts
@@ -43,7 +43,13 @@ export class ConnectorService {
     }
 
     handleAuthProcess(ingestIp: string, obsName: string, groupCode: string, leftTeam: AuthTeam, rightTeam: AuthTeam, key: string, win: Electron.Main.BrowserWindow) {
-        this.INGEST_SERVER_URL = `https://${ingestIp}:5100`;
+        if (RegExp('(http|https)://[^/]+:[0-9]+').test(ingestIp)) {
+            this.INGEST_SERVER_URL = `${ingestIp}`
+        } else if (RegExp('.+:.+').test(ingestIp) && !(ingestIp.startsWith('http'))) {
+            this.INGEST_SERVER_URL = `https://${ingestIp}`
+        } else {
+            this.INGEST_SERVER_URL = ingestIp.startsWith('http') ? `${ingestIp}:5100` : `https://${ingestIp}:5100`
+        }
         this.OBS_NAME = obsName;
         this.GROUP_CODE = groupCode.toUpperCase();
         this.LEFT_TEAM = leftTeam;

--- a/src/services/connectorService.ts
+++ b/src/services/connectorService.ts
@@ -45,11 +45,12 @@ export class ConnectorService {
     handleAuthProcess(ingestIp: string, obsName: string, groupCode: string, leftTeam: AuthTeam, rightTeam: AuthTeam, key: string, win: Electron.Main.BrowserWindow) {
         if (RegExp('(http|https)://[^/]+:[0-9]+').test(ingestIp)) {
             this.INGEST_SERVER_URL = `${ingestIp}`
-        } else if (RegExp('.+:.+').test(ingestIp) && !(ingestIp.startsWith('http'))) {
+        } else if (ingestIp.includes(':') && !(ingestIp.startsWith('http'))) {
             this.INGEST_SERVER_URL = `https://${ingestIp}`
         } else {
             this.INGEST_SERVER_URL = ingestIp.startsWith('http') ? `${ingestIp}:5100` : `https://${ingestIp}:5100`
         }
+        log.info(this.INGEST_SERVER_URL)
         this.OBS_NAME = obsName;
         this.GROUP_CODE = groupCode.toUpperCase();
         this.LEFT_TEAM = leftTeam;


### PR DESCRIPTION
This will add regex which will do the following:

* Check if ```(http or https)://(hostname or ip):(port)``` are present, which will set Ingest URL to ```input```
* If not, then check if ```(hostname or ip):(port)``` are present, which will set Ingest URL to ```http:// + input```
* If none if those are true, then check if ```(http or https)://(hostname or ip)``` are present, which will set Ingest URL to ```input:5100```

Some of those use regex, other use ```ingestIp.startsWith('http')```. I could use entirely with regex but given how much it giving me insanity, this would be sufficient.