### PR TITLE
Added recommended image size into tournament info

### DIFF
--- a/angular/src/app/sponsor/sponsor.component.html
+++ b/angular/src/app/sponsor/sponsor.component.html
@@ -1,6 +1,13 @@
 <div class="border-surface flex flex-col gap-3 rounded-lg border p-5">
   <div class="flex items-center gap-2">
     <h1 class="text-color text-xl font-bold">Sponsors</h1>
+    <i
+      class="text-md! pi pi-info size-min cursor-pointer rounded-full border p-1"
+      (click)="info_popover.toggle($event)"
+    ></i>
+    <p-popover #info_popover>
+      <p class="">Recommended image size: 156x71 / 2.2:1</p>
+    </p-popover>
     <p-toggleswitch
       id="ShowTournamentInfo"
       [(ngModel)]="data.enabled"

--- a/angular/src/app/tournamentinfo/tournamentinfo.component.html
+++ b/angular/src/app/tournamentinfo/tournamentinfo.component.html
@@ -8,7 +8,7 @@
     <p-popover #info_popover>
       <p class="">Recommended image size:</p>
       <p class="">Logo: Any size with a 1:1 aspect ratio</p>
-      <p class="">Backdrop: 875x200 / 35:8 - 830x250 / 83:25 on Nobii VCT Style</p>
+      <p class="">Backdrop: 875x200 / 35:8 - 830x250 / 83:25 on Nobii's Style</p>
     </p-popover>
   </div>
   <div class="grid grid-cols-12">

--- a/angular/src/app/tournamentinfo/tournamentinfo.component.html
+++ b/angular/src/app/tournamentinfo/tournamentinfo.component.html
@@ -8,7 +8,7 @@
     <p-popover #info_popover>
       <p class="">Recommended image size:</p>
       <p class="">Logo: Any size with a 1:1 aspect ratio</p>
-      <p class="">Backdrop: 875x200 / 35:8 aspect ratio</p>
+      <p class="">Backdrop: 875x200 / 35:8 - 830x250 / 83:25 on Nobii VCT Style</p>
     </p-popover>
   </div>
   <div class="grid grid-cols-12">

--- a/angular/src/app/tournamentinfo/tournamentinfo.component.html
+++ b/angular/src/app/tournamentinfo/tournamentinfo.component.html
@@ -1,6 +1,16 @@
 <div class="border-surface flex flex-col gap-3 rounded-lg border p-5">
-  <h1 class="text-color text-xl font-bold">Tournament Info</h1>
-
+  <div class="flex items-center gap-2">
+    <h1 class="text-color text-xl font-bold">Tournament Info</h1>
+    <i
+      class="text-md! pi pi-info size-min cursor-pointer rounded-full border p-1"
+      (click)="info_popover.toggle($event)"
+    ></i>
+    <p-popover #info_popover>
+      <p class="">Recommended image size:</p>
+      <p class="">Logo: Any size with a 1:1 aspect ratio</p>
+      <p class="">Backdrop: 875x200 / 35:8 aspect ratio</p>
+    </p-popover>
+  </div>
   <div class="grid grid-cols-12">
     <div class="col-span-5 flex flex-col justify-around">
       <div class="flex content-center gap-2">


### PR DESCRIPTION
Hi,

I thought it would be useful to have the image sizes, especially for the tournament backdrop, so I added a small infobox (in the same style as the watermark one)

I just signed the CLA -> https://github.com/ValoSpectra/CLA/pull/3

