### PR TITLE
Fix the mappool validation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -365,7 +365,7 @@ function processInputs(
     let allow = true;
     for (const map of seriesInfo.mapInfo!) {
       if (map.type === "past") {
-        if (map.map === "" || map.left.score < 0 || map.right.score < 0) {
+        if (map.map === "" || map.left.score <= 0 || map.right.score <= 0) {
           allow = false;
           break;
         }


### PR DESCRIPTION
When the score of a map is at 13 - 0, you got an error when you try to connect "Please input data into all fields!"

