### PR TITLE
feat: autosave aux-client ingest server

### DIFF
--- a/angular/src/app/AuxiliaryComponent/auxiliary.component.html
+++ b/angular/src/app/AuxiliaryComponent/auxiliary.component.html
@@ -9,6 +9,7 @@
       <p-select
         fluid
         [(ngModel)]="ingestServerIp"
+        (ngModelChange)="save()"
         [options]="ingestServerOptions"
         [readonly]="!editable"
         [editable]="true"

--- a/angular/src/app/AuxiliaryComponent/auxiliary.component.ts
+++ b/angular/src/app/AuxiliaryComponent/auxiliary.component.ts
@@ -92,6 +92,10 @@ export class AuxiliaryComponent implements OnInit {
 
   protected editable: boolean = true;
 
+  protected save() {
+    this.localStorageService.setItem("auxIngestServerIp", this.ingestServerIp);
+  }
+
   protected connect() {
     if (!this.ingestServerIp) {
       this.messageService.add({


### PR DESCRIPTION
The Player Client should auto save the ingest server, so if the Player doesn't go into a Custom Game, it would still save it.
This was a main "issue" for the tournament I am helping at, the players forgot to select the server after the first setup the day before and so, we hadn't had auxiliary data from these players.

And this would also
close #25 